### PR TITLE
Basic support for callbacks

### DIFF
--- a/pymetabiosis/bindings.py
+++ b/pymetabiosis/bindings.py
@@ -37,6 +37,7 @@ ffi.cdef("""
          void PyErr_Print();
          void PyErr_Clear();
          int PyErr_ExceptionMatches(PyObject *exc);
+         void PyErr_SetString(PyObject *type, const char *message);
          PyObject* const PyExc_BaseException;
          PyObject* const PyExc_Exception;
          PyObject* const PyExc_StandardError;

--- a/pymetabiosis/test/test_wrapper.py
+++ b/pymetabiosis/test/test_wrapper.py
@@ -263,5 +263,9 @@ def test_callbacks_exceptions():
     with pytest.raises(KeyError):
         builtin.apply(fn, (2,))
     # exception in converting result
-    with pytest.raises(NoConvertError): # FIXME - can we?
+    try:
         builtin.apply(lambda : object())
+    except SystemError:
+        assert False
+    except Exception:
+        pass


### PR DESCRIPTION
Also a minor but maybe controversial thing - in order to wrap and unwrap unhashable objects (in my case this was a some_dict.get method as callback), I store them in identity_dict.
