### PR TITLE
__add__, __mul__, __int__ method for the Wrapper class

### DIFF
--- a/pymetabiosis/wrapper.py
+++ b/pymetabiosis/wrapper.py
@@ -114,6 +114,13 @@ class MetabiosisWrapper(object):
         op = pymetabiosis.module.import_module("operator")
         return op.add(self, b)
 
+    def __mul__(self, b):
+        op = pymetabiosis.module.import_module("operator")
+        return op.mul(self, b)
+
+    def __int__(self):
+        return pypy_convert_int(self.obj)
+
     def __repr__(self):
         py_str = ffi.gc(lib.PyObject_Repr(self.obj), lib.Py_DECREF)
         return pypy_convert(py_str)


### PR DESCRIPTION
Trying:

```
builtin = import_module("numpy")
x = np.arange(5)
x + 0.5
```

Raises a `TypeError`. This PR includes an `__add__`, `__mul__` and an `__int__` method.
