### PR TITLE
Add rpath

### DIFF
--- a/pymetabiosis/bindings.py
+++ b/pymetabiosis/bindings.py
@@ -43,7 +43,17 @@ def _get_library_dirs():
         [PYTHON, "-c",
          "from distutils import sysconfig;"
          "print sysconfig.get_config_var('LIBDIR')"]
-    )]
+    ).strip()]
+
+LIBDIRS = _get_library_dirs()
+
+def _get_extra_link_args():
+    args = []
+    if sys.platform == 'darwin' or sys.platform.startswith("linux"):
+        libdir = LIBDIRS[0]
+        args.append("-Wl,-rpath,%s"%os.path.dirname(libdir))
+
+    return args
 
 
 ffi = FFI()
@@ -196,7 +206,8 @@ lib = ffi.verify("""
                  """,
                  include_dirs=_get_include_dirs(),
                  libraries=["python2.7"],
-                 library_dirs=_get_library_dirs(),
+                 library_dirs=LIBDIRS,
+                 extra_link_args=_get_extra_link_args(),
                  flags=ffi.RTLD_GLOBAL)
 
 prog_name = ffi.new("char[]", PYTHON)

--- a/pymetabiosis/bindings.py
+++ b/pymetabiosis/bindings.py
@@ -49,9 +49,12 @@ LIBDIRS = _get_library_dirs()
 
 def _get_extra_link_args():
     args = []
-    if sys.platform == 'darwin' or sys.platform.startswith("linux"):
+    if sys.platform == 'darwin':
         libdir = LIBDIRS[0]
         args.append("-Wl,-rpath,%s"%os.path.dirname(libdir))
+    elif sys.platform.startswith("linux"):
+        libdir = LIBDIRS[0]
+        args.append("-Wl,-rpath,%s"%libdir)
 
     return args
 


### PR DESCRIPTION
This makes it easy for a user to embed a Python.  This works correctly on OSX and Linux.  Tested on system Python and also with Canopy.
