### PR TITLE
ndarray support

### DIFF
--- a/pymetabiosis/numpy_convert.py
+++ b/pymetabiosis/numpy_convert.py
@@ -40,28 +40,38 @@ def register_pypy_cpy_ndarray_converters():
 _convert_ndarray = applevel('''
 import numpy
 import ctypes
-def _convert_ndarray(shape, dtype, size, addr):
+def _convert_ndarray(shape, dtype, size, strides, offset, addr):
     return numpy.ndarray(
         shape=shape,
         dtype=dtype,
+        strides=strides,
+        offset=offset,
         buffer=(ctypes.c_char*size).from_address(addr))
 return _convert_ndarray
 ''', noconvert=True)
 
 def convert_ndarray(obj):
+    base = obj if obj.base is None else obj.base
+    offset = obj.__array_interface__['data'][0] - base.__array_interface__['data'][0]
     w = _convert_ndarray(
         obj.shape,
         obj.dtype.name,
-        len(obj.data),
-        obj.__array_interface__["data"][0])
+        len(base.data),
+        obj.strides,
+        offset,
+        base.__array_interface__["data"][0])
     return ffi.gc(w._cpyobj, lib.Py_DECREF)
 
 _convert_from_ndarray = applevel('''
 def _convert_from_ndarray(obj):
+    base = obj if obj.base is None else obj.base
+    offset = obj.__array_interface__['data'][0] - base.__array_interface__['data'][0]
     return (obj.shape,
             obj.dtype.name,
-            len(obj.data),
-            obj.__array_interface__["data"][0])
+            len(base.data),
+            obj.strides,
+            offset,
+            base.__array_interface__["data"][0])
 return _convert_from_ndarray
 ''')
 
@@ -72,9 +82,11 @@ except ImportError:
     pass
 else:
     def convert_from_ndarray(obj):
-        shape, dtype, size, addr = _convert_from_ndarray\
+        shape, dtype, size, strides, offset, addr = _convert_from_ndarray\
             ._call((obj,), args_kwargs_converted=True)
         return numpy.ndarray(
             shape=shape,
             dtype=dtype,
+            strides=strides,
+            offset=offset,
             buffer=(ctypes.c_char*size).from_address(addr))

--- a/pymetabiosis/test/test_numpy_convert.py
+++ b/pymetabiosis/test/test_numpy_convert.py
@@ -1,15 +1,13 @@
 import pytest
 from pymetabiosis.module import import_module
 from pymetabiosis.numpy_convert import \
-        register_cpy_numpy_to_pypy_builtin_converters
+        register_cpy_numpy_to_pypy_builtin_converters, \
+        register_pypy_cpy_numpy_converters
 
-register_cpy_numpy_to_pypy_builtin_converters()
 
 def test_scalar_converter():
-    try:
-        numpy = import_module("numpy")
-    except ImportError:
-        pytest.skip("numpy isn't installed on the cpython side")
+    numpy = _import_cpy_numpy()
+    register_cpy_numpy_to_pypy_builtin_converters()
 
     assert numpy.bool_(True) is True
     assert numpy.bool_(False) is False
@@ -25,3 +23,29 @@ def test_scalar_converter():
     if hasattr(numpy, "float128"):
         assert numpy.float128(-42.0) == -42.0
 
+
+def test_pypy_numpy_converter():
+    pypy_numpy = _import_pypy_numpy()
+    cpython_numpy = _import_cpy_numpy()
+    register_pypy_cpy_numpy_converters()
+    arr = pypy_numpy.zeros(2) + 1
+    assert cpython_numpy.sum(arr) == 2.0
+    # TODO - returning from cpython_numpy
+   #cpython_numpy.add(m1, m2, out=m1)
+   #assert m1[1][1] == 3
+
+
+def _import_pypy_numpy():
+    try:
+        import numpy
+    except ImportError:
+        pytest.skip("numpy isn't installed on pypy side")
+    else:
+        return numpy
+
+
+def _import_cpy_numpy():
+    try:
+        return import_module("numpy")
+    except ImportError:
+        pytest.skip("numpy isn't installed on the cpython side")

--- a/pymetabiosis/test/test_numpy_convert.py
+++ b/pymetabiosis/test/test_numpy_convert.py
@@ -52,7 +52,10 @@ def test_pypy_ndarray_converter():
     assert type(m3) is np.ndarray
     assert m3.dtype is m1.dtype
     assert m3[1][1] == 11
-
+    a = np.random.random(30) + 1j*np.random.rand(30)
+    x = cpython_numpy.fft.fft(a)
+    assert type(x) is np.ndarray
+    assert x.shape == (30,)
 
 def _import_pypy_numpy():
     try:

--- a/pymetabiosis/test/test_numpy_convert.py
+++ b/pymetabiosis/test/test_numpy_convert.py
@@ -25,11 +25,23 @@ def test_scalar_converter():
 
 
 def test_pypy_numpy_converter():
-    pypy_numpy = _import_pypy_numpy()
+    np = _import_pypy_numpy()
     cpython_numpy = _import_cpy_numpy()
+    builtin = import_module("__builtin__", noconvert=True)
+    operator = import_module("operator", noconvert=True)
     register_pypy_cpy_numpy_converters()
-    arr = pypy_numpy.zeros(2) + 1
+    arr = np.zeros(2) + 1
     assert cpython_numpy.sum(arr) == 2.0
+    arr = np.array([2, 3], dtype=np.int8)
+    assert cpython_numpy.sum(arr) == 5
+    for dtype in [
+            np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32,
+            np.int64, np.uint64,
+            np.float16, np.float32, np.float64]:
+        m = np.zeros((17, 13), dtype=dtype)
+        assert builtin.len(m) == 17
+        assert operator.attrgetter('dtype.name')(m) == dtype.__name__
+        assert operator.attrgetter('shape')(m) == (17, 13)
     # TODO - returning from cpython_numpy
    #cpython_numpy.add(m1, m2, out=m1)
    #assert m1[1][1] == 3

--- a/pymetabiosis/test/test_numpy_convert.py
+++ b/pymetabiosis/test/test_numpy_convert.py
@@ -57,6 +57,14 @@ def test_pypy_ndarray_converter():
     assert type(x) is np.ndarray
     assert x.shape == (30,)
 
+def test_pypy_ndarray_offset_handling():
+    np = _import_pypy_numpy()
+    cpython_numpy = _import_cpy_numpy()
+    register_pypy_cpy_ndarray_converters()
+    x = np.asarray((complex(1, 2), complex(3, 4)))
+    assert cpython_numpy.sum(x.real) == 4.0
+    assert cpython_numpy.sum(x.imag) == 6.0
+
 def _import_pypy_numpy():
     try:
         import numpy

--- a/pymetabiosis/wrapper.py
+++ b/pymetabiosis/wrapper.py
@@ -14,7 +14,7 @@ def convert(obj):
             pass
     if getattr(obj, '_pymetabiosis_wrap', None):
         return convert_unknown(obj)
-    raise NoConvertError(type(obj))
+    raise NoConvertError(_type)
 
 def convert_string(s):
     return ffi.gc(lib.PyString_FromString(ffi.new("char[]", s)), lib.Py_DECREF)


### PR DESCRIPTION
This branch adds converters for numpy.ndarray (PyPy <-> CPython), fixing issue #16. These converters need to be registered by calling register_pypy_cpy_ndarray_converters. Perhaps for better usability we should auto-enable them?
