### PR TITLE
Add a simple import hook for pymetabiosis.

### DIFF
--- a/pymetabiosis/auto.py
+++ b/pymetabiosis/auto.py
@@ -1,0 +1,4 @@
+"""Importing this module will auto-inject the import hook.
+"""
+from pymetabiosis.import_hook import auto
+auto()

--- a/pymetabiosis/import_hook.py
+++ b/pymetabiosis/import_hook.py
@@ -1,0 +1,59 @@
+import sys
+import imp
+from pymetabiosis import import_module
+
+
+class PyMetabiosisHook(object):
+    """An import hook to first try importing in pypy and if that fails, try
+    with the embedded CPython via `pymetabiosis.import_module`.
+    """
+    def __init__(self):
+        self.module = None
+
+    def _is_root_package_in_pypy(self, fullname):
+        """Checks if the first package in the module given is in pypy or not.
+
+        For example, if IPython.core is imported, then IPython is the "root"
+        package.
+        """
+        root = fullname.split('.')[0]
+        result = True
+        try:
+            info = imp.find_module(root)
+        except ImportError:
+            result = False
+        return result
+
+    def find_module(self, fullname, path=None):
+        module = None
+        if not self._is_root_package_in_pypy(fullname):
+            module = import_module(fullname)
+        self.module = module
+        return self if module is not None else None
+
+    def load_module(self, name):
+        module = self.module
+        sys.modules[name] = module
+        return module
+
+
+def add_numpy_converters():
+    from pymetabiosis import numpy_convert
+    numpy_convert.register_pypy_cpy_ndarray_converters()
+    numpy_convert.register_cpy_numpy_to_pypy_builtin_converters()
+
+
+def install():
+    """Install the import_hook and automatically uninstall it at exit.
+
+    Not removing the hook causes problems and segfaults when exiting the
+    interpreter.
+    """
+
+    import_hook = PyMetabiosisHook()
+    sys.meta_path.append(import_hook)
+    import atexit
+    atexit.register(lambda: sys.meta_path.remove(import_hook))
+
+add_numpy_converters()
+install()

--- a/pymetabiosis/import_hook.py
+++ b/pymetabiosis/import_hook.py
@@ -49,11 +49,9 @@ def install():
     Not removing the hook causes problems and segfaults when exiting the
     interpreter.
     """
+    add_numpy_converters()
 
     import_hook = PyMetabiosisHook()
     sys.meta_path.append(import_hook)
     import atexit
     atexit.register(lambda: sys.meta_path.remove(import_hook))
-
-add_numpy_converters()
-install()

--- a/pymetabiosis/import_hook.py
+++ b/pymetabiosis/import_hook.py
@@ -37,21 +37,22 @@ class PyMetabiosisHook(object):
         return module
 
 
-def add_numpy_converters():
-    from pymetabiosis import numpy_convert
-    numpy_convert.register_pypy_cpy_ndarray_converters()
-    numpy_convert.register_cpy_numpy_to_pypy_builtin_converters()
-
-
 def install():
-    """Install the import_hook and automatically uninstall it at exit.
+    """Install the import_hook and return a function that removes the
+    hook when called (with no arguments).
 
     Not removing the hook causes problems and segfaults when exiting the
     interpreter.
     """
-    add_numpy_converters()
-
     import_hook = PyMetabiosisHook()
     sys.meta_path.append(import_hook)
+    return lambda: sys.meta_path.remove(import_hook)
+
+
+def auto():
+    """Automatically install the import hook and uninstall the hook
+    via atexit.
+    """
+    from pymetabiosis.import_hook import install
     import atexit
-    atexit.register(lambda: sys.meta_path.remove(import_hook))
+    atexit.register(install())

--- a/pymetabiosis/test/test_import_hook.py
+++ b/pymetabiosis/test/test_import_hook.py
@@ -1,0 +1,48 @@
+import sys
+import pytest
+
+from pymetabiosis.import_hook import install
+from pymetabiosis.wrapper import applevel
+
+
+def inject_spam():
+    # Creates a spam module in CPython.
+    applevel('''
+import sys, types
+m = types.ModuleType('spam')
+m.x = 1
+sys.modules['spam'] = m
+''', noconvert=False)
+
+@pytest.fixture(scope="function")
+def import_hook(request):
+    inject_spam()
+    uninstall = install()
+    request.addfinalizer(uninstall)
+
+def test_pypy_cannot_import_spam():
+    # Without the import hook, this should raise an ImportError.
+    with pytest.raises(ImportError):
+        import spam    
+     
+def test_import_hook_imports_cpython_spam(import_hook):
+    import spam
+    assert spam.__name__ == 'spam'
+    assert spam.x == 1
+
+    with pytest.raises(ImportError):
+        # Should not import.
+        import eggs_and_ham
+    # Cleanup.
+    del sys.modules['spam']
+
+def test_import_hook_is_correctly_uninstalled():
+    # Given
+    inject_spam()
+    uninstall = install()
+    
+    # When.
+    uninstall()
+
+    with pytest.raises(ImportError):
+        import spam


### PR DESCRIPTION
This hook first checks if the module is available in pypy and if not
found, it uses pymetabiosis to import the module in the embedded
CPython.
