### PR TITLE
Fix Travis-CI to use pypy-2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ addons:
         - python-numpy
 cache: pip
 install:
-    - pypy -V
     - echo $PATH
+    - curl -O https://bootstrap.pypa.io/get-pip.py
+    - /usr/bin/pypy get-pip.py --user
     - /usr/bin/pypy -m pip install --user -r requirements.txt git+https://bitbucket.org/pypy/numpy
 script: /usr/bin/pypy -m py.test
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ addons:
         - python-numpy
 cache: pip
 install:
-    - pypy -m pip install --user -r requirements.txt git+https://bitbucket.org/pypy/numpy
-script: pypy -m py.test
+    - pypy -V
+    - echo $PATH
+    - /usr/bin/pypy -m pip install --user -r requirements.txt git+https://bitbucket.org/pypy/numpy
+script: /usr/bin/pypy -m py.test
 env:
     - PYTHON_EMBED=/usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
         packages:
         - pypy
         - python-numpy
+        - pypy-dev
 cache: pip
 install:
     - echo $PATH


### PR DESCRIPTION
This fixes travis-ci to actually use the ppa pypy-2.6.1 instead of 2.5.x as it was doing before.  This now fixes the tests and is RTM.
